### PR TITLE
Ensure that the Python installation directory is included in the archive

### DIFF
--- a/bin/archive
+++ b/bin/archive
@@ -19,7 +19,7 @@ fi
 
 set -o xtrace
 
-: ${TAR_PATHS:=}
+: ${TAR_PATHS:=$INSTALL_DEST/$VERSION}
 : ${DESTS:=}
 
 if [[ $VERSION =~ ^python|pypy ]] ; then

--- a/bin/archive
+++ b/bin/archive
@@ -47,7 +47,7 @@ fi
 
 for DEST in $DESTS ; do
   mkdir -p $(dirname $DEST)
-  tar -cjf $DEST $TAR_PATHS
+  tar -cjvf $DEST $TAR_PATHS
 
   pushd $(dirname $DEST) &>/dev/null
 

--- a/bin/archive
+++ b/bin/archive
@@ -47,7 +47,7 @@ fi
 
 for DEST in $DESTS ; do
   mkdir -p $(dirname $DEST)
-  tar -cjvf $DEST $TAR_PATHS
+  tar -cjf $DEST $(ls -d $TAR_PATHS 2>/dev/null || true)
 
   pushd $(dirname $DEST) &>/dev/null
 


### PR DESCRIPTION
This fixes https://github.com/travis-ci/travis-ci/issues/5268.

With `VERSION=3.5.0` and `ALIAS=3.5`, we are currently skipping the directory `/opt/python/3.5.0`, which includes shared library, causing https://github.com/travis-ci/travis-ci/issues/5268. This PR ensures that this does not happen when `ALIAS` does not start with `python` or `pypy`.
