### PR TITLE
Build with ucs4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ before_script:
 - 'export OS_NAME=${OS_NAME:-$(lsb_release -is | tr "A-Z" "a-z" || echo "osx")}'
 - 'export ARCH=${ARCH:-$(uname -m)}'
 - 'export PACKAGES=${PACKAGES:-pip numpy nose pytest mock wheel}'
+- export PYTHON_COFIGURE_OPTS="$CONFIGURE_OPTS --enable-unicode=ucs4"
 
 script: ./bin/compile
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ matrix:
 
 env:
   global:
-  - VERSION='3.5.0'
-  - ALIAS='3.5'
+  - VERSION='2.7.10'
+  - ALIAS=$VERSION
 
 install:
 - pushd /opt/pyenv/


### PR DESCRIPTION
Currently, we are building Python runtimes with ucs2.

This PR will change this to ucs4, which was the prior configuration.

It fixes https://github.com/travis-ci/travis-ci/issues/5107.
