### PR TITLE
Fix alias creation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
 
 env:
   global:
-    - VERSION='3.5.0'
+    - VERSION='3.5.2'
     - ALIAS='3.5'
 
 install:

--- a/build-python
+++ b/build-python
@@ -1,5 +1,13 @@
 #!/usr/bin/env bash
 
+fold_start() {
+  echo -e "travis_fold:start:$1\033[33;1m$2\033[0m"
+}
+
+fold_end() {
+  echo -e "\ntravis_fold:end:$1\r"
+}
+
 set -o errexit
 
 if [[ ! $INSTALL_DEST ]] ; then
@@ -14,14 +22,24 @@ fi
 
 set -o xtrace
 
+fold_start "python-build" "Building Python $VERSION"
+
 sudo env PYTHON_BUILD_ROOT=/opt/pyenv/plugins/python-build \
   PYTHON_CONFIGURE_OPTS="--enable-shared" \
   /opt/pyenv/plugins/python-build/bin/python-build $VERSION $INSTALL_DEST/$VERSION
+
+fold_end "python-build"
+
+fold_start "alias" "Setting up alias $ALIAS"
 
 if [[ $ALIAS ]] ; then
   sudo rm -f $INSTALL_DEST/$ALIAS
   sudo ln -s $INSTALL_DEST/$VERSION $INSTALL_DEST/$ALIAS
 fi
+
+fold_end "alias"
+
+fold_start virtualenv "Setting up virtualenv"
 
 virtualenv --distribute --python=$INSTALL_DEST/$VERSION/bin/python \
   /home/travis/virtualenv/python$VERSION
@@ -31,6 +49,12 @@ if [[ $ALIAS ]] ; then
   ln -s $HOME/virtualenv/python$VERSION $HOME/virtualenv/python$ALIAS
 fi
 
+fold_end virtualenv
+
+fold_start packages "Installing packages $PACKAGES"
+
 if [[ $PACKAGES ]] ; then
   $HOME/virtualenv/python$VERSION/bin/pip install --upgrade $PACKAGES
 fi
+
+fold_end

--- a/build-python
+++ b/build-python
@@ -19,6 +19,7 @@ sudo env PYTHON_BUILD_ROOT=/opt/pyenv/plugins/python-build \
   /opt/pyenv/plugins/python-build/bin/python-build $VERSION $INSTALL_DEST/$VERSION
 
 if [[ $ALIAS ]] ; then
+  sudo rm -f $INSTALL_DEST/$ALIAS
   sudo ln -s $INSTALL_DEST/$VERSION $INSTALL_DEST/$ALIAS
 fi
 
@@ -26,6 +27,7 @@ virtualenv --distribute --python=$INSTALL_DEST/$VERSION/bin/python \
   /home/travis/virtualenv/python$VERSION
 
 if [[ $ALIAS ]] ; then
+  rm -f $HOME/virtualenv/python$ALIAS
   ln -s $HOME/virtualenv/python$VERSION $HOME/virtualenv/python$ALIAS
 fi
 


### PR DESCRIPTION
The rationale is explained in https://github.com/travis-ci/cpython-builder/commit/6e337142c421c31ea99c13c1b51f373ea48fff20:
# Remove potentially existent aliases

Before creating symbolic links to aliases, remove targets first.
Notice that we cannot use `ln -sf` for some reason; the `-f` flag
seems to be ignored on a few tests I have run.

This is an issue when we are building on an image that already
has `$INSTALL_DEST/$ALIAS`, because `ln -s ...` is ineffective,
and the alias still points to a potentially nonexistent directory.
