### PR TITLE
Fix PYTHON_CONFIGURE_OPTS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_script:
 - 'export ARCH=${ARCH:-$(uname -m)}'
 - 'export PACKAGES=${PACKAGES:-pip nose pytest mock wheel}'
 - 'export CPYTHON_ONLY_PKGS="numpy"'
-- export PYTHON_COFIGURE_OPTS="$CONFIGURE_OPTS --enable-unicode=ucs4"
+- export PYTHON_CONFIGURE_OPTS="$CONFIGURE_OPTS"
 
 script: ./bin/compile
 

--- a/bin/compile
+++ b/bin/compile
@@ -40,6 +40,8 @@ if [[ $ALIAS ]] ; then
   ln -s $HOME/virtualenv/$VIRTENV_VERSION $HOME/virtualenv/python$ALIAS
 fi
 
+$HOME/virtualenv/$VIRTENV_VERSION/bin/python -c "import sys; assert sys.maxunicode > 65535"
+
 if [[ $PACKAGES ]] ; then
   $HOME/virtualenv/$VIRTENV_VERSION/bin/pip install --upgrade $PACKAGES
 fi


### PR DESCRIPTION
PYTHON_CONFIGURE_OPTS was mispelt as PYTHON_COFIGURE_OPTS.

Building with --enable-unicode=ucs4 is now the default
since https://github.com/yyuu/pyenv/issues/257 on February 2016.
