### PR TITLE
Add support for Ubuntu Xenial builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@ language: python
 matrix:
   include:
     - sudo: required
+      language: minimal
+      dist: xenial
+      group: edge
+      env: RELEASE=xenial
+    - sudo: required
       services: docker
       env: RELEASE=trusty
     - sudo: required


### PR DESCRIPTION
Seems to work well :-)
https://travis-ci.org/edmorley/cpython-builder/jobs/300985835

(Since the builds are green I didn't add to `allowed_failures`)