### PR TITLE
Travis CI: sudo tag is now deprecated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,22 +6,18 @@ stage: build
 
 jobs:
   include:
-    - sudo: required
-      language: minimal
+    - language: minimal
       dist: xenial
       group: edge
       env: RELEASE=xenial
-    - sudo: required
-      dist: trusty
+    - dist: trusty
       services: docker
       env: RELEASE=trusty
       if: NOT env(VERSION) =~ -dev$ AND NOT env(VERSION) =~ ^3\.[789]
-    - sudo: required
-      dist: precise
+    - dist: precise
       env: RELEASE=precise
       if: NOT env(VERSION) =~ -dev$ AND NOT env(VERSION) =~ ^pypy AND NOT env(VERSION) =~ ^3\.[789]
-    - sudo: required
-      arch: ppc64le
+    - arch: ppc64le
       dist: xenial
       env: RELEASE=xenial
 


### PR DESCRIPTION
[Travis CI now recommends removing the __sudo__ tag](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).

"_If you currently specify __sudo: false__ in your __.travis.yml__, we recommend removing that configuration_"