### PR TITLE
Fix 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ install:
 - sudo git checkout master
 - sudo git pull
 - popd
-- python -m pip install --upgrade virtualenv
+- sudo python3 -m pip install --upgrade virtualenv
 
 before_script:
 - 'export INSTALL_DEST=${INSTALL_DEST:-/opt/python}'
@@ -97,6 +97,7 @@ addons:
       - openssl
       - libssl-dev
       - mercurial
+      - python3-pip
   artifacts:
     paths:
     - $LSB_RELEASE/

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ install:
 - sudo git checkout master
 - sudo git pull
 - popd
-- python -m pip install virtualenv
+- python -m pip install --upgrade virtualenv
 
 before_script:
 - 'export INSTALL_DEST=${INSTALL_DEST:-/opt/python}'

--- a/bin/compile
+++ b/bin/compile
@@ -47,7 +47,7 @@ else
   VIRTENV_VERSION=python$VERSION
 fi
 
-virtualenv --distribute --python=$INSTALL_DEST/$VERSION/bin/$PYTHON_BIN \
+virtualenv --python=$INSTALL_DEST/$VERSION/bin/$PYTHON_BIN \
   $HOME/virtualenv/$VIRTENV_VERSION
 
 if [[ $ALIAS ]] ; then

--- a/bin/compile
+++ b/bin/compile
@@ -17,16 +17,6 @@ function install_numpy() {
   $HOME/virtualenv/$VIRTENV_VERSION/bin/pip install --upgrade numpy
 }
 
-function install_numpy_from_source() {
-  pushd $HOME/build
-  git clone https://github.com/numpy/numpy.git numpy/numpy
-  pushd numpy/numpy
-  $HOME/virtualenv/$VIRTENV_VERSION/bin/pip install nose pytz cython
-  $HOME/virtualenv/$VIRTENV_VERSION/bin/pip install .
-  popd
-  popd
-}
-
 sudo env PYTHON_BUILD_ROOT=/opt/pyenv/plugins/python-build \
   /opt/pyenv/plugins/python-build/bin/python-build --verbose $VERSION $INSTALL_DEST/$VERSION
 
@@ -66,9 +56,7 @@ if [[ $PACKAGES ]] ; then
   $HOME/virtualenv/$VIRTENV_VERSION/bin/pip install --upgrade $PACKAGES
 fi
 
-if [[ "${ALIAS}" = nightly ]]; then
-  install_numpy_from_source
-else
+if ! [[ "${ALIAS}" == nightly || "${VERSION}" =~ '-dev$' ]]; then
   if [[ ${VERSION} == pypy* ]]; then
     $HOME/virtualenv/$VIRTENV_VERSION/bin/${PYTHON_BIN} -m ensurepip
   fi

--- a/bin/compile
+++ b/bin/compile
@@ -28,7 +28,7 @@ function install_numpy_from_source() {
 }
 
 sudo env PYTHON_BUILD_ROOT=/opt/pyenv/plugins/python-build \
-  /opt/pyenv/plugins/python-build/bin/python-build $VERSION $INSTALL_DEST/$VERSION
+  /opt/pyenv/plugins/python-build/bin/python-build --verbose $VERSION $INSTALL_DEST/$VERSION
 
 if [[ $ALIAS ]] ; then
   rm -f $INSTALL_DEST/$ALIAS


### PR DESCRIPTION
https://travis-ci.community/t/python-3-9-support/6703

See commit messages for details.

---

Optional modules were removed for prerelease versions because [Cython doesn't support 3.9](https://travis-ci.org/native-api/cpython-builder/jobs/632913617#L9668) -- and cannot get a chance to support it as a result as explained in a commit message below.

Are they really needed in other versions as well? If a project requires `numpy`, it has it in its `requirements.txt` and the chance of versions here and there matching exactly is small.

---

Failure in `xenial arm64` is a known problem with GCC 5: https://travis-ci.community/t/segfaults-in-arm64-environment/5617.