### PR TITLE
Fix 3.9 for Multiarch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ install:
 - sudo git checkout master
 - sudo git pull
 - popd
-- python -m pip install --upgrade virtualenv
+- sudo python3 -m pip install --upgrade virtualenv
 
 before_script:
 - 'export INSTALL_DEST=${INSTALL_DEST:-/opt/python}'
@@ -97,6 +97,7 @@ addons:
       - openssl
       - libssl-dev
       - mercurial
+      - python3-pip
   artifacts:
     paths:
     - $LSB_RELEASE/

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,12 +36,12 @@ jobs:
       language: minimal
     - arch: s390x
       dist: xenial
-      name: xenial-ppc64le
+      name: xenial-s390x
       os: linux
       language: minimal
     - arch: s390x
       dist: bionic
-      name: bionic-ppc64le
+      name: bionic-s390x
       os: linux
       language: minimal
     - arch: arm64
@@ -53,6 +53,9 @@ jobs:
       name: bionic-arm64
       language: minimal
 
+  allow_failures:
+    - name: xenial-arm64
+
 env:
   global:
   - VERSION=3.8-dev
@@ -63,7 +66,24 @@ install:
 - sudo git checkout master
 - sudo git pull
 - popd
-- sudo python3 -m pip install --upgrade virtualenv
+# As of this writing:
+# * Py2 is EOL
+#   * however, pip (https://pip.pypa.io/en/latest/development/release-process/#python-2-support) intends to keep supporting it as long as practical
+#   * Virtualenv also supports old versions (e.g. 3.4) far longer than PSF does
+# * selected images have `virtualenv` on PATH for stem Py2 preinstalled (installed with pip); for amd64 globally, for multiarch per user
+#   * this preinstalled `virtualenv` doesn't support 3.9+
+# * selected amd64 images have 3.7.* preinstalled with pip; multiarch have pyenv not on PATH, with no alt versions
+# * xenial's provided Py3, 3.5, is in security fixes mode, due for EOL in 06.2020
+#
+# So it seems to be safe to use the py2 preinstalled `virtualenv` if we update it, for the foreseeable future.
+# FIXME: use an officially supported alt Python version for `virtualenv` instead once one is available in all images.
+- |
+  # `cat` avoids "broken pipe"; `freeze` instead of `list` avoids a warning about future output format change
+  if (python -m pip freeze --user | cat | grep -qP '^virtualenv=='); then
+    python -m pip install --upgrade --user virtualenv
+  elif (python -m pip freeze | cat | grep -qP '^virtualenv=='); then
+    sudo python -m pip install --upgrade virtualenv
+  fi
 
 before_script:
 - 'export INSTALL_DEST=${INSTALL_DEST:-/opt/python}'

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ install:
 - sudo git checkout master
 - sudo git pull
 - popd
-- python -m pip install virtualenv
+- python -m pip install --upgrade virtualenv
 
 before_script:
 - 'export INSTALL_DEST=${INSTALL_DEST:-/opt/python}'

--- a/bin/compile
+++ b/bin/compile
@@ -56,7 +56,7 @@ if [[ $PACKAGES ]] ; then
   $HOME/virtualenv/$VIRTENV_VERSION/bin/pip install --upgrade $PACKAGES
 fi
 
-if ! [[ "${ALIAS}" == nightly || "${VERSION}" =~ '-dev$' ]]; then
+if ! [[ "${ALIAS}" == nightly || "${VERSION}" =~ -dev$ ]]; then
   if [[ ${VERSION} == pypy* ]]; then
     $HOME/virtualenv/$VIRTENV_VERSION/bin/${PYTHON_BIN} -m ensurepip
   fi

--- a/bin/compile
+++ b/bin/compile
@@ -47,7 +47,7 @@ else
   VIRTENV_VERSION=python$VERSION
 fi
 
-virtualenv --distribute --python=$INSTALL_DEST/$VERSION/bin/$PYTHON_BIN \
+virtualenv --python=$INSTALL_DEST/$VERSION/bin/$PYTHON_BIN \
   $HOME/virtualenv/$VIRTENV_VERSION
 
 if [[ $ALIAS ]] ; then

--- a/bin/compile
+++ b/bin/compile
@@ -17,16 +17,6 @@ function install_numpy() {
   $HOME/virtualenv/$VIRTENV_VERSION/bin/pip install --upgrade numpy
 }
 
-function install_numpy_from_source() {
-  pushd $HOME/build
-  git clone https://github.com/numpy/numpy.git numpy/numpy
-  pushd numpy/numpy
-  $HOME/virtualenv/$VIRTENV_VERSION/bin/pip install nose pytz cython
-  $HOME/virtualenv/$VIRTENV_VERSION/bin/pip install .
-  popd
-  popd
-}
-
 sudo env PYTHON_BUILD_ROOT=/opt/pyenv/plugins/python-build \
   /opt/pyenv/plugins/python-build/bin/python-build --verbose $VERSION $INSTALL_DEST/$VERSION
 
@@ -66,9 +56,7 @@ if [[ $PACKAGES ]] ; then
   $HOME/virtualenv/$VIRTENV_VERSION/bin/pip install --upgrade $PACKAGES
 fi
 
-if [[ "${ALIAS}" = nightly ]]; then
-  install_numpy_from_source
-else
+if ! [[ "${ALIAS}" == nightly || "${VERSION}" =~ '-dev$' ]]; then
   if [[ ${VERSION} == pypy* ]]; then
     $HOME/virtualenv/$VIRTENV_VERSION/bin/${PYTHON_BIN} -m ensurepip
   fi

--- a/bin/compile
+++ b/bin/compile
@@ -28,7 +28,7 @@ function install_numpy_from_source() {
 }
 
 sudo env PYTHON_BUILD_ROOT=/opt/pyenv/plugins/python-build \
-  /opt/pyenv/plugins/python-build/bin/python-build $VERSION $INSTALL_DEST/$VERSION
+  /opt/pyenv/plugins/python-build/bin/python-build --verbose $VERSION $INSTALL_DEST/$VERSION
 
 if [[ $ALIAS ]] ; then
   rm -f $INSTALL_DEST/$ALIAS


### PR DESCRIPTION
Problems that I cannot fix without further info and/or your clearance:

* (minor) A still supported version of Python is not available in all used images to be used as a base for `virtualenv`.
    * It _seems_ safe to use system Py2 for a foreseeable future though (coudn't find hard evidence but Virtualenv seems to support old versions for quite some time).
       * Despite that, I can use alt 3.7.1 for Virtualenv -- if there are images for multiarch that have it preinstalled. Are there?
* Can't test other values for VERSION and ALIAS that you pass to builds.
    * Will need to add many more jobs for that so that a PR build checks all possible combinations. Shall I do that?
        * I can make inputs compatible with current custom build requests: when there are no custom build data, everything is built, when there is, only what is specified in the data is built.
        * Also need a list of possible inputs for custom build values that you use in (scheduled?) build requests to compose the list of jobs to add.