### PR TITLE
React to Virtualenv 20 behavior change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,12 +70,12 @@ install:
 # * Py2 is EOL
 #   * however, pip (https://pip.pypa.io/en/latest/development/release-process/#python-2-support) intends to keep supporting it as long as practical
 #   * Virtualenv also supports old versions (e.g. 3.4) far longer than PSF does
-# * selected images have `virtualenv` on PATH for stem Py2 preinstalled (installed with pip); for amd64 globally, for multiarch per user
-#   * this preinstalled `virtualenv` doesn't support 3.9+
+# * all images have `virtualenv` on PATH but vary in whether it's per-user or global and which Python installation it belongs to
+#   * some of these preinstalled `virtualenv`s don't support 3.9+
 # * selected amd64 images have 3.7.* preinstalled with pip; multiarch have pyenv not on PATH, with no alt versions
 # * xenial's provided Py3, 3.5, is in security fixes mode, due for EOL in 06.2020
 #
-# So it seems to be safe to use the py2 preinstalled `virtualenv` if we update it, for the foreseeable future.
+# So it seems to be safe to use `virtualenv` with system's Py2 if we update it, for the foreseeable future.
 # FIXME: use an officially supported alt Python version for `virtualenv` instead once one is available in all images.
 - |
   # `cat` avoids "broken pipe"; `freeze` instead of `list` avoids a warning about future output format change
@@ -83,6 +83,8 @@ install:
     python -m pip install --upgrade --user virtualenv
   elif (python -m pip freeze | cat | grep -qP '^virtualenv=='); then
     sudo python -m pip install --upgrade virtualenv
+  else
+    sudo python -m pip install virtualenv
   fi
 
 before_script:

--- a/bin/compile
+++ b/bin/compile
@@ -42,7 +42,7 @@ fi
 # 20.0.2+ copies by default instead but the devs plan to change that back sometime.
 # 'pip' seeder is the old behavior and is not planned for deprecation in the foreseeable future
 # (https://github.com/pypa/virtualenv/issues/1576#issuecomment-584769625).
-virtualenv --python=$INSTALL_DEST/$VERSION/bin/$PYTHON_BIN \
+python -m virtualenv --python=$INSTALL_DEST/$VERSION/bin/$PYTHON_BIN \
   --seeder=pip \
   $HOME/virtualenv/$VIRTENV_VERSION
 

--- a/bin/compile
+++ b/bin/compile
@@ -37,7 +37,13 @@ else
   VIRTENV_VERSION=python$VERSION
 fi
 
+# We must have everything under virtualenv's subtree to be able to tarball it.
+# Virtualenv 20+ puts preinstalled modules (pip, setuptools, wheel) into a shared location and symlinks to them.
+# 20.0.2+ copies by default instead but the devs plan to change that back sometime.
+# 'pip' seeder is the old behavior and is not planned for deprecation in the foreseeable future
+# (https://github.com/pypa/virtualenv/issues/1576#issuecomment-584769625).
 virtualenv --python=$INSTALL_DEST/$VERSION/bin/$PYTHON_BIN \
+  --seeder=pip \
   $HOME/virtualenv/$VIRTENV_VERSION
 
 if [[ $ALIAS ]] ; then


### PR DESCRIPTION
Technically, after 20.0.2, no changes are needed,
but pip seeder looks more future-proof.

References: https://travis-ci.community/t/python-development-versions-no-longer-include-pip-due-to-virtualenv-20-x/7180, https://github.com/pypa/virtualenv/issues/1576